### PR TITLE
bug with duplicate login servers

### DIFF
--- a/linux/server_launcher.pl
+++ b/linux/server_launcher.pl
@@ -171,7 +171,7 @@ while (1) {
     if (!$print_status_once) {
         #::: Loginserver Process
         if ($use_loginserver) {
-            for ($i = $loginserver_process_count; $i < 2; $i++) {
+            for ($i = $loginserver_process_count; $i < 1; $i++) {
                 system($base_binary_path . "loginserver " . $pipe_redirection . " " . $background_start);
                 $loginserver_process_count++;
                 print_status();


### PR DESCRIPTION
Logic allowed for the login server to spawn twice, two loginserver processes and two log files.  They would then fight over local ports and users would see the dreaded black server list.